### PR TITLE
Sync repo with public one

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ The following environment variables are supported. You can pass environment vari
 |`SUMO_COLLECTOR_EPHEMERAL`  |When true, the collector will be deleted after it goes offline for 12 hours. <br><br>Default: true.|
 |`SUMO_COLLECTOR_NAME`       |Configures the name of the collector. The default is set dynamically to the value in `/etc/hostname`.|
 |`SUMO_COLLECTOR_NAME_PREFIX`|Configures a prefix to the collector name. Useful when overriding `SUMO_COLLECTOR_NAME` with the Docker hostname.<br><br>Default: "collector_container-"<br><br>If you do not want a prefix, set the variable as follows: <br><br>`SUMO_COLLECTOR_NAME_PREFIX = ""`|
+|`SUMO_COLLECTOR_HOSTNAME`   |Sets the host name of the machine on which the Collector container is running.<br><br> Default: The container ID.|
 |`SUMO_DISABLE_SCRIPTS`       |If your organization's internal policies restrict the use of scripts, you can disable the creation of script-based script sources. When this parameter is passed, this option is removed from the Sumo web application, and script source cannot be configured.<br><br> Default: false.|
 |`SUMO_GENERATE_USER_PROPERTIES`|Set this variable to “false” if you are providing the collector configuration settings using a `user.properties` file via a Docker volume mount.|
 |`SUMO_JAVA_MEMORY_INIT`      |Sets the initial java heap size (in MB). <br><br>Default: 64|

--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ The following environment variables are supported. You can pass environment vari
 |`SUMO_PROXY_USER`            |Sets proxy user when a proxy server is used with authentication.|
 |`SUMO_SOURCES_JSON`          |Specifies the path to the `sumo-sources.json` file. <br><br>Default: `/etc/sumo-sources.json`. |
 |`SUMO_SYNC_SOURCES`          |If “true”, the `SUMO_SOURCES_JSON` file(s) will be continuously monitored and synchronized with the Collector's configuration. This will also disable editing of the collector in the Sumo UI. <br><br>Default: false|
+|`SUMO_FIPS_JCE`              |If "true", the FIPS 140-2 compliant Java Cryptography Extension (JCE) would be used to encrypt the data. <br><br>Default: false|
 
 ### Configure collector in user.properties file
 You can supply source configuration values using a `user.properties` file via a Docker volume mount. For information about supported properties, see [user.properties](http://help.sumologic.com/Send_Data/Installed_Collectors/05Reference_Information_for_Collector_Installation/06user.properties) in Sumo help. For information about Docker volumes, see [Use Volumes](https://docs.docker.com/engine/admin/volumes/volumes/) in Docker help.

--- a/run.sh
+++ b/run.sh
@@ -112,10 +112,11 @@ generate_user_properties_file() {
 # If the user didn't supply their own user.properties file, generate it
 $SUMO_GENERATE_USER_PROPERTIES && {
     generate_user_properties_file
-    if [ "${SUMO_FIPS_JCE}" == "true" ]; then
-        /opt/SumoCollector/script/configureFipsMode.sh
-    fi
 }
+
+if [ "${SUMO_FIPS_JCE}" == "true" ]; then
+    /opt/SumoCollector/script/configureFipsMode.sh
+fi
 
 # Don't leave our shell hanging around
 exec /opt/SumoCollector/collector console

--- a/run.sh
+++ b/run.sh
@@ -112,6 +112,9 @@ generate_user_properties_file() {
 # If the user didn't supply their own user.properties file, generate it
 $SUMO_GENERATE_USER_PROPERTIES && {
     generate_user_properties_file
+    if [ "${SUMO_FIPS_JCE}" == "true" ]; then
+        /opt/SumoCollector/script/configureFipsMode.sh
+    fi
 }
 
 # Don't leave our shell hanging around


### PR DESCRIPTION
Two changes from the public repo
1. https://github.com/SumoLogic/sumologic-collector-docker/pull/81 (Add support to enable the FIPS compliant JCE)
2. https://github.com/SumoLogic/sumologic-collector-docker/pull/82 (Update README.md for hostname env variable)

@guptakeshav-sumo